### PR TITLE
Triangle Indicator Fix

### DIFF
--- a/css/mint.css
+++ b/css/mint.css
@@ -1,0 +1,3 @@
+.rhmsc-fix-triangle .disclosure-triangle {
+    transform: rotate(0deg);
+}

--- a/html/settings.html
+++ b/html/settings.html
@@ -24,6 +24,7 @@
 						<ul>
 							<li><a href="#first" class="active">Welcome Page</a></li>
 							<li><a href="#second">Analytics</a></li>
+							<li><a href="#triangleFix">Triangle Indicator Fix</a></li>
 						</ul>
 					</nav>
 
@@ -44,6 +45,14 @@
 								<p>This extension sends analytics on usage including the time it takes for a sync to complete, when the extension is being used, and how long users ineract with the extension's pages. You can turn this tracking off using this setting. You must restart your browser for the change to take effect.</p>
 								<input type="checkbox" id="setting-disableAnalytics" name="setting-disableAnalytics">
 								<label for="setting-disableAnalytics">Disable analytics</label>
+							</section>
+							<section id="triangleFix" class="main">
+								<header class="major">
+									<h2>Triangle Indicator Fix</h2>
+								</header>
+								<p>In some areas of Mint, there is an expansion panel where the indicator functions counterintuitively. This setting enables a fix so that the indiacator for the panel appears expanded when it should.</p>
+								<input type="checkbox" id="setting-triangleFix" name="setting-triangleFix">
+								<label for="setting-triangleFix">Triangle Indicator Fix</label>
 							</section>
 					</div>
 

--- a/html/settings.html
+++ b/html/settings.html
@@ -50,7 +50,7 @@
 								<header class="major">
 									<h2>Triangle Indicator Fix</h2>
 								</header>
-								<p>In some areas of Mint, there is an expansion panel where the indicator functions counterintuitively. This setting enables a fix so that the indiacator for the panel appears expanded when it should.</p>
+								<p>In some areas of Mint, there is an expansion panel where the indicator functions counterintuitively. This setting enables a fix so that the indicator for the panel appears expanded when it should.</p>
 								<input type="checkbox" id="setting-fixTriangle" name="setting-fixTriangle">
 								<label for="setting-fixTriangle">Triangle Indicator Fix</label>
 							</section>

--- a/html/settings.html
+++ b/html/settings.html
@@ -22,15 +22,15 @@
 				<!-- Nav -->
 					<nav id="nav">
 						<ul>
-							<li><a href="#first" class="active">Welcome Page</a></li>
-							<li><a href="#second">Analytics</a></li>
+							<li><a href="#welcome" class="active">Welcome Page</a></li>
+							<li><a href="#analytics">Analytics</a></li>
 							<li><a href="#triangleFix">Triangle Indicator Fix</a></li>
 						</ul>
 					</nav>
 
 				<!-- Main -->
 					<div id="main">
-							<section id="first" class="main">
+							<section id="welcome" class="main">
 								<header class="major">
 									<h2>Changelog</h2>
 								</header>
@@ -38,7 +38,7 @@
 								<input type="checkbox" id="setting-changelogOnUpdate" name="setting-changelogOnUpdate">
 								<label for="setting-changelogOnUpdate">Display changelog on update</label>
 							</section>
-							<section id="second" class="main">
+							<section id="analytics" class="main">
 								<header class="major">
 									<h2>Analytics</h2>
 								</header>

--- a/html/settings.html
+++ b/html/settings.html
@@ -51,8 +51,8 @@
 									<h2>Triangle Indicator Fix</h2>
 								</header>
 								<p>In some areas of Mint, there is an expansion panel where the indicator functions counterintuitively. This setting enables a fix so that the indiacator for the panel appears expanded when it should.</p>
-								<input type="checkbox" id="setting-triangleFix" name="setting-triangleFix">
-								<label for="setting-triangleFix">Triangle Indicator Fix</label>
+								<input type="checkbox" id="setting-fixTriangle" name="setting-fixTriangle">
+								<label for="setting-fixTriangle">Triangle Indicator Fix</label>
 							</section>
 					</div>
 

--- a/js/mint/mint.js
+++ b/js/mint/mint.js
@@ -1,0 +1,11 @@
+chrome.storage.sync.get({"fixTriangle": true}, function(result) {
+    if (result.fixTriangle) {
+        $(`
+<style>
+.rhmsc-fix-triangle .disclosure-triangle {
+    transform: rotate(0deg);
+}
+</style>
+`)
+    }
+});

--- a/js/mint/mint.js
+++ b/js/mint/mint.js
@@ -1,5 +1,3 @@
-chrome.storage.sync.get({"fixTriangle": true}, function(result) {
-    if (result.fixTriangle) {
-        $("body").addClass("rhmsc-fix-triangle");
-    }
+chrome.storage.sync.get({"fixTriangle": true}, result => {
+    if (result.fixTriangle) document.getElementsByTagName("body")[0].classList.add("rhmsc-fix-triangle");
 });

--- a/js/mint/mint.js
+++ b/js/mint/mint.js
@@ -1,11 +1,5 @@
 chrome.storage.sync.get({"fixTriangle": true}, function(result) {
     if (result.fixTriangle) {
-        $(`
-<style>
-.rhmsc-fix-triangle .disclosure-triangle {
-    transform: rotate(0deg);
-}
-</style>
-`)
+        $("body").addClass("rhmsc-fix-triangle");
     }
 });

--- a/js/settings.js
+++ b/js/settings.js
@@ -1,10 +1,13 @@
-chrome.storage.sync.get({"changelogOnUpdate": true, "disableAnalytics": false}, function(result) {
+chrome.storage.sync.get({"changelogOnUpdate": true, "disableAnalytics": false, "fixTriangle": true}, function(result) {
     console.log(result);
     if (result.changelogOnUpdate) {
         $("#setting-changelogOnUpdate").prop("checked", true);
     }
     if (result.disableAnalytics) {
         $("#setting-disableAnalytics").prop("checked", true);
+    }
+    if (result.fixTriangle) {
+        $("#setting-fixTriangle").prop("checked", true);
     }
     $("#setting-changelogOnUpdate").change(function() {
         chrome.storage.sync.set({"changelogOnUpdate":  $("#setting-changelogOnUpdate").is(':checked')});
@@ -13,5 +16,8 @@ chrome.storage.sync.get({"changelogOnUpdate": true, "disableAnalytics": false}, 
         console.log("change");
         console.log($("#setting-disableAnalytics").is(':checked'));
         chrome.storage.sync.set({"disableAnalytics":  $("#setting-disableAnalytics").is(':checked')});
+    });
+    $("#setting-fixTriangle").change(function() {
+        chrome.storage.sync.set({"fixTriangle":  $("#setting-fixTriangle").is(':checked')});
     });
 });

--- a/manifest.json
+++ b/manifest.json
@@ -48,6 +48,11 @@
             "matches": ["https://mint.intuit.com/overview.event*"],
             "js": ["js/external/jquery/jquery.min.js","js/external/noty/noty.js", "js/mint/mint-overview.js"],
             "css": ["css/mint-overview.css","css/noty.css"]
+        },
+        {
+            "matches": ["https://mint.intuit.com/*"],
+            "js": ["js/mint/mint.js"],
+            "css": ["css/mint.css"]
         }
 
     ],


### PR DESCRIPTION
In some areas of Mint, there is an expansion panel where the indicator functions counterintuitively. This setting enables a fix so that the indicator for the panel works like most other websites/UIs.

### Goes from:

#### Expanded:
![image](https://user-images.githubusercontent.com/8972556/66620315-9d23a180-eba5-11e9-9215-f887ec199445.png)

#### Collapsed:
![image](https://user-images.githubusercontent.com/8972556/66620321-a90f6380-eba5-11e9-8be3-039ec4f3974a.png)


### To:

#### Expanded:
![image](https://user-images.githubusercontent.com/8972556/66620085-d7d90a00-eba4-11e9-8c26-d70e37e33d5d.png)

#### Collapsed:
![image](https://user-images.githubusercontent.com/8972556/66620100-ea534380-eba4-11e9-99dd-1163f1ba3280.png)
