### PR TITLE
Fix Issue #22

### DIFF
--- a/src/content/mint/properties/update.ts
+++ b/src/content/mint/properties/update.ts
@@ -76,7 +76,6 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
         const robinhoodInputs = property.querySelectorAll("input");
 
         // Bail & Recur if this isn't our input for some reason.
-        // thisProperty as HTMLElement).innerText.includes(label) can give false positives
         if (robinhoodInputs[0].value !== `Robinhood ${label}`) {
           debug.log(`Failed to set to set ${label} to ${amount}. Bad Input Value. Value: ${robinhoodInputs[0].value}. Attempt # ${timesCalled}.`);
           setTimeout(() => setRobinhoodAmount(label, amount, timesCalled + 1), 50);


### PR DESCRIPTION
Fixes the updating issue from the 3.x update.

If the user has any "automatic update" properties such as a house that is connected to Zillow or a car connected to Kelly Blue Book, `thisProperty as HTMLElement).innerText.includes(label)` returns a false positive causing the update to never finish.
(These properties have a hidden "Add Another" button)